### PR TITLE
add revertable

### DIFF
--- a/revolut/__init__.py
+++ b/revolut/__init__.py
@@ -470,6 +470,7 @@ class Transaction(_UpdateFromKwargsMixin):
     reference = None
     merchant = None
     card = None
+    revertable = False
 
     def __init__(self, **kwargs):
         self.client = kwargs.pop("client")


### PR DESCRIPTION
While building a service around this library, i noticed that if the transaction is new, there's a `revertable` attribute, which it doesn't support.
Added it with `default=False`

Probably could also be added as a property (not sure):
```
@property
def revertable(self):
    return self.state == 'pending'
```

```
service_1   | [2022-05-15 08:31:27,404: ERROR/ForkPoolWorker-2] Task payments.tasks.load_revolut_transactions[bad11cfc-211b-4eae-96d4-27a5331c6d64] raised unexpected: ValueError("Excess keyword for <class 'revolut.Transaction'>: revertable = True")
service_1   | Traceback (most recent call last):
service_1   |   File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 451, in trace_task
service_1   |     R = retval = fun(*args, **kwargs)
service_1   |   File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 734, in __protected_call__
service_1   |     return self.run(*args, **kwargs)
service_1   |   File "/code/payments/tasks.py", line 145, in load_revolut_transactions
service_1   |     for transaction in client.transactions(from_date=from_date):
service_1   |   File "/usr/local/lib/python3.8/site-packages/revolut/__init__.py", line 158, in transactions
service_1   |     txn = Transaction(client=self, **txdat)
service_1   |   File "/usr/local/lib/python3.8/site-packages/revolut/__init__.py", line 476, in __init__
service_1   |     self._update(**kwargs)
service_1   |   File "/usr/local/lib/python3.8/site-packages/revolut/__init__.py", line 496, in _update
service_1   |     super(Transaction, self)._update(**kwargs)
service_1   |   File "/usr/local/lib/python3.8/site-packages/revolut/__init__.py", line 173, in _update
service_1   |     raise ValueError(
service_1   | ValueError: Excess keyword for <class 'revolut.Transaction'>: revertable = True

```